### PR TITLE
Escape input before passing to git grep

### DIFF
--- a/lib/git/gsub.rb
+++ b/lib/git/gsub.rb
@@ -17,11 +17,13 @@ module Git
     end
 
     def self.gsub *args
-      from, to, path, = args
+      from, to, path, = args.map do |arg|
+        Shellwords.escape arg if arg
+      end
 
       target_files = (`git grep -l #{from} #{path}`).each_line.map(&:chomp).join ' '
 
-      system %|gsed -i s/#{Shellwords.escape from}/#{Shellwords.escape to}/g #{target_files}|
+      system %|gsed -i s/#{from}/#{to}/g #{target_files}|
     end
   end
 end


### PR DESCRIPTION
```
$ git gsub '<h1 *class="foo">' '<h1 class="bar">'
sh: -c: line 0: syntax error near unexpected token `newline'
sh: -c: line 0: `git grep -l <h1 *class="foo"> '
```
