### PR TITLE
@ needs to be escaped in perl regex

### DIFF
--- a/lib/git/gsub.rb
+++ b/lib/git/gsub.rb
@@ -103,6 +103,7 @@ module Git
 
         def build_command(from, to, paths = [], _options = {})
           from, to, *paths = [from, to, *paths].map { |s| Shellwords.escape s }
+          [from, to].each { |s| s.gsub! '@', '\@' }
 
           target_files = `git grep -l #{from} #{paths.join ' '}`.each_line.map(&:chomp).join ' '
           return if target_files.empty?

--- a/spec/git_gsub_spec.rb
+++ b/spec/git_gsub_spec.rb
@@ -49,6 +49,11 @@ describe 'git-gsub' do
       Git::Gsub.run [%({git{svn}), %({hg{svn})]
       expect(File.read('README.md')).to eq %({hg{svn})
     end
+
+    run_in_directory_with_a_file 'README.md', %(foo@example.com) do
+      Git::Gsub.run [%(@example), %(bar@example)]
+      expect(File.read('README.md')).to eq %(foobar@example.com)
+    end
   end
 
   it 'should not create backup file' do


### PR DESCRIPTION
Without this fix, the attached test fails with the following result:

```
expected: "foobar@example.com"
     got: "barfbarobarobar@barebarxbarabarmbarpbarlbarebar.barcbarobarmbar"
```

I don't exactly understand why, but maybe this is because `@` in the pattern is interpreted as a perl Array sigil (?).