### PR TITLE
Fix substitution to empty string

### DIFF
--- a/lib/git/gsub.rb
+++ b/lib/git/gsub.rb
@@ -103,20 +103,11 @@ module Git
         end
 
         def build_command(from, to, paths = [], _options = {})
-          from, to, *paths = [from, to, *paths].map { |s|
-            if s == ''
-              ''
-            else
-              Shellwords.escape s
-            end
-          }
-          [from, to].each { |s| s.gsub! '@', '\@' }
-
-          target_files = `git grep -l #{from} #{paths.join ' '}`.each_line.map(&:chomp)
+          target_files = `git grep -l #{from.shellescape} #{paths.join ' '}`.each_line.map(&:chomp)
           return if target_files.empty?
 
 
-          ['perl', '-pi', '-e', "s{#{from}}{#{to}}g", *target_files]
+          ['perl', '-i', '-pe', 'BEGIN {$from=shift;$to=shift} s/\Q$from\E/$to/g', from, to, *target_files]
         end
       end
 

--- a/lib/git/gsub.rb
+++ b/lib/git/gsub.rb
@@ -103,7 +103,13 @@ module Git
         end
 
         def build_command(from, to, paths = [], _options = {})
-          from, to, *paths = [from, to, *paths].map { |s| Shellwords.escape s }
+          from, to, *paths = [from, to, *paths].map { |s|
+            if s == ''
+              ''
+            else
+              Shellwords.escape s
+            end
+          }
           [from, to].each { |s| s.gsub! '@', '\@' }
 
           target_files = `git grep -l #{from} #{paths.join ' '}`.each_line.map(&:chomp)

--- a/spec/git_gsub_spec.rb
+++ b/spec/git_gsub_spec.rb
@@ -91,6 +91,13 @@ describe 'git-gsub' do
     expect(File.read('README.md')).to eq %({hg{svn})
   end
 
+  it 'should substitute text to empty'do
+    commit_file 'README.md', "Git Svn Hg"
+    Git::Gsub.run [%(Svn ), %()]
+
+    expect(File.read('README.md')).to eq %(Git Hg)
+  end
+
   it 'should not create backup file' do
     commit_file 'README.md', 'Git Subversion Bzr'
     Git::Gsub.run %w[Bzr Darcs]


### PR DESCRIPTION
`Shellwords#shellescape` 'Returns an empty quoted String if str has a length of zero.',
but we need empty non-quoted string here.

https://ruby-doc.org/stdlib-2.5.1/libdoc/shellwords/rdoc/Shellwords.html