### PR TITLE
Call git ls-files with -z option to properly handle multibyte filenames

### DIFF
--- a/e2e_test.go
+++ b/e2e_test.go
@@ -257,6 +257,17 @@ func TestSubstituteToEmptyString(t *testing.T) {
 	})
 }
 
+func TestUTF8Filename(t *testing.T) {
+	RunInTmpRepo(func() {
+		CommitFile("よんでね.txt", "よんでね")
+		RunGitGsub("でね", "だよ")
+		dat, _ := ioutil.ReadFile("./よんでね.txt")
+		if string(dat) != "よんだよ" {
+			t.Errorf("Failed: %s", string(dat))
+		}
+	})
+}
+
 func TestSimpleRename(t *testing.T) {
 	RunInTmpRepo(func() {
 		CommitFile("README-git_gsub.md", "GitGsub git_gsub git-gsub")

--- a/main.go
+++ b/main.go
@@ -26,6 +26,7 @@ type Substitution struct {
 func getAllFiles(paths []string) []string {
 	var args []string
 	args = append(args, "ls-files")
+	args = append(args, "-z")
 	args = append(args, paths...)
 	cmd := exec.Command("git", args...)
 	out, err := cmd.Output()
@@ -33,7 +34,7 @@ func getAllFiles(paths []string) []string {
 	if exitCode != 1 && err != nil {
 		log.Fatal(err)
 	}
-	lines := strings.Split(string(out), "\n")
+	lines := strings.Split(string(out), "\x00")
 	return lines
 }
 


### PR DESCRIPTION
Current version of git-gsub fails to handle files with non-ASCII filename.
Not just fails to read / write from such files, it aborts whenever being executed on a repo that contains such a file, regardless of whether the file contains the target string or not.

This is because `git ls-files` octal-escapes and quotes "unusual" strings (see: https://git-scm.com/docs/git-config#Documentation/git-config.txt-corequotePath ), and `os.Stat()` [here](https://github.com/fujimura/git-gsub/blob/343d13a/main.go#L45) fails to find the file.
For such usecase, `git ls-files` equips with `-z` option that literally outputs the list of filenames terminated by a NUL byte.
Quoted below is what the official documentation says. https://git-scm.com/docs/git-ls-files#_output

> Without the -z option, pathnames with "unusual" characters are quoted as explained for the configuration variable core.quotePath (see git-config[1]). Using -z the filename is output verbatim and the line is terminated by a NUL byte.

The attached patch implements this and enables git-gsub to properly handle my 🍖🍻🤘.md.