### PR TITLE
Introduce -F option for "fixed string" (a.k.a. fgrep) search

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,11 +9,12 @@ $ git gsub
 Usage git gsub [options] FROM TO [PATHS]
 
 Options:
-      --camel     Substitute camel-cased expressions
-      --kebab     Substitute kebab-cased expressions
-      --rename    Rename files with expression
-      --snake     Substitute snake-cased expressions
-      --version   Show version
+      --camel       Substitute camel-cased expressions
+      --kebab       Substitute kebab-cased expressions
+      --rename      Rename files with expression
+      --snake       Substitute snake-cased expressions
+      -F, --fgrep   Interpret given pattern as a fixed string
+      --version     Show version
 ```
 
 ## Example

--- a/e2e_test.go
+++ b/e2e_test.go
@@ -169,6 +169,18 @@ func TestOptionsCanBePutAfterArguments(t *testing.T) {
 	})
 }
 
+func TestSubstitutionWithFixedStringOption(t *testing.T) {
+	RunInTmpRepo(func() {
+		CommitFile("hello.rb", "puts('hello')")
+		RunGitGsub("--fgrep", "(", " ")
+		RunGitGsub("-F", ")", "")
+		dat, _ := ioutil.ReadFile("./hello.rb")
+		if string(dat) != "puts 'hello'" {
+			t.Errorf("Failed: %s", string(dat))
+		}
+	})
+}
+
 func TestEscape(t *testing.T) {
 	RunInTmpRepo(func() {
 		CommitFile("README.md", `<h1 class="foo">`)

--- a/main.go
+++ b/main.go
@@ -104,6 +104,7 @@ func main() {
 	var kebab = flag.Bool("kebab", false, "Substitute kebab-cased expressions")
 	var camel = flag.Bool("camel", false, "Substitute camel-cased expressions")
 	var rename = flag.Bool("rename", false, "Rename files with expression")
+	var fgrep = flag.BoolP("fgrep", "F", false, "Interpret given pattern as a fixed string")
 	var version = flag.Bool("version", false, "Show version")
 
 	flag.Parse()
@@ -120,8 +121,13 @@ func main() {
 		flag.PrintDefaults()
 		os.Exit(1)
 	}
+
 	rawFrom := args[0]
+	if *fgrep {
+		rawFrom = regexp.QuoteMeta(rawFrom)
+	}
 	to := args[1]
+
 	var targetPaths []string
 	if len(args) > 2 {
 		targetPaths = args[2:]


### PR DESCRIPTION
I use git-gsub mainly for program source files, and I very often have to replace some special chars such as `()[]{}+-*/'"\` etc.
It is indeed very hard to properly escape and quote strings containing such characters in the terminal, so I'd like to propose something equivalent to `-F` in `grep`.