### PR TITLE
Release a channel even if an error occurs

### DIFF
--- a/main.go
+++ b/main.go
@@ -203,12 +203,10 @@ func (cli *CLI) Run(_args []string) int {
 		go func(path_ string) {
 			cn <- true
 			err := runSubstitionsAndRenames(substitutions, *rename, path_)
-			if err == nil {
-				<-cn
-			} else {
+			if err != nil {
 				errCn <- err
-				close(cn)
 			}
+			<-cn
 			wg.Done()
 		}(path)
 	}


### PR DESCRIPTION
`git-gsub` sometimes panics when invalid symlinks exist in a repository.

```sh
mkdir test-repo
cd test-repo
git init
touch z.txt
ln -s /foo/hoge
git add .
git commit -m 'first commit'
```

then

```sh
cd test-repo
for i in {0..30}; do
  env GIT_GSUB_MAX_PROC=1 ../bin/git-gsub 'a' 'b'
done
```

I think `git-gsub` should release a channel and not close a channel if an error occurs.

before

The program sometimes panics.

```
 directorystat hoge: no such file or directorystat hoge: no such file or directorypanic: send on closed channel

goroutine 22 [running]:
main.(*CLI).Run.func2({0xc0001ac255, 0x5})
	/Users/hiroakiizu/ghq/github.com/akihiro17/git-gsub/main.go:204 +0x5e
created by main.(*CLI).Run
	/Users/hiroakiizu/ghq/github.com/akihiro17/git-gsub/main.go:203 +0xa1b
stat hoge: no such file or directorystat hoge: no such file or directorystat hoge: no such file or directorystat hoge: no such file or directorypanic: send on closed channel

goroutine 22 [running]:
main.(*CLI).Run.func2({0xc000132255, 0x5})
	/Users/hiroakiizu/ghq/github.com/akihiro17/git-gsub/main.go:204 +0x5e
created by main.(*CLI).Run
	/Users/hiroakiizu/ghq/github.com/akihiro17/git-gsub/main.go:203 +0xa1b
stat hoge: no such file or directorystat hoge: no such file or directorystat hoge: no such file or directorystat hoge: no such file or directorystat hoge: no such file or directory⏎
```

after

it just outputs errors
```
stat hoge: no such file or directorystat hoge: no such file or directorystat hoge: no such file or directorystat hoge: no such file or directorystat hoge: no such file or directorystat hoge: no such file or directorystat hoge: no such file or directorystat hoge: no such file or directorystat hoge: no such file or directorystat hoge: no such file or directorystat hoge: no such file or directorystat hoge: no such file or directorystat hoge: no such file or directorystat hoge: no such file or directorystat hoge: no such file or directorystat hoge: no such file or directorystat hoge: no such file or directorystat hoge: no such file or directorystat hoge: no such file or directorystat hoge: no such file or directorystat hoge: no such file or directorystat hoge: no such file or directorystat hoge: no such file or directorystat hoge: no such file or directorystat hoge: no such file or directorystat hoge: no such file or directorystat hoge: no such file or directorystat hoge: no such file or directorystat hoge: no such file or directorystat hoge: no such file or directorystat hoge: no such file or directory⏎
```